### PR TITLE
Mark all files as read-only

### DIFF
--- a/src/Nanicitus.Core/SymbolIndexer.cs
+++ b/src/Nanicitus.Core/SymbolIndexer.cs
@@ -702,6 +702,7 @@ namespace Nanicitus.Core
                 }
 
                 File.Copy(sourceFile, destinationFile);
+                File.SetAttributes(destinationFile, FileAttributes.ReadOnly);
 
                 m_Diagnostics.Log(
                     LevelToLog.Info,


### PR DESCRIPTION
All files should be marked as read-only (more important for the source files than for the binary files) so that they can't be changed randomly.
