### PR TITLE
Deploy script should re-use existing version number file

### DIFF
--- a/Build.GatherReleaseNotes.msbuild
+++ b/Build.GatherReleaseNotes.msbuild
@@ -31,6 +31,8 @@
     
     <Import Project="$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild" 
             Condition="Exists('$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild')" />
+    <Import Project="$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild" 
+            Condition="Exists('$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild')" />
     <Import Project="$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild" 
             Condition="Exists('$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild')" />
     <Import Project="$(MsBuildExtensionsPath)\TemplateFile.msbuild"
@@ -49,13 +51,16 @@
     
     <PropertyGroup>
         <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
     <Target Name="_GetSemanticVersion">
         <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
             <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
         </FindToolFromPackages>
         
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+        <CalculateSemanticVersion ExePath="$(PathGitVersionExe)" VersionFile="$(FileSemanticVersion)" Condition="!Exists('$(FileSemanticVersion)')" />
+        
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionSemantic" PropertyName="VersionSemantic" />
         </GetSemanticVersion>
     </Target>

--- a/Deploy.GitTag.msbuild
+++ b/Deploy.GitTag.msbuild
@@ -20,36 +20,21 @@
     
     <Import Project="$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild" 
             Condition="Exists('$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild')" />
-    <Import Project="$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild" 
-            Condition="Exists('$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild')" />
     <Import Project="$(MsBuildExtensionsPath)\NugetRestore.msbuild"
             Condition="Exists('$(MsBuildExtensionsPath)\NugetRestore.msbuild')"/>    
     
-    <Target Name="Run" DependsOnTargets="_DisplayInfo;_RestorePackages;_GetSemanticVersion;_LoadReleaseNotes;_TagRelease;" />
+    <Target Name="Run" DependsOnTargets="_DisplayInfo;_GetSemanticVersion;_LoadReleaseNotes;_TagRelease;" />
     
     <!-- Display info -->
     <Target Name="_DisplayInfo">
         <Message Text="Tagging release ..." />
     </Target>
     
-    <!-- Run Nuget for the global build -->
     <PropertyGroup>
-        <FileNuGetExe>$(DirSrc)\.nuget\NuGet.exe</FileNuGetExe>
-        <PackagesConfig>$([System.IO.Path]::Combine($(DirWorkspace), "packages.config"))</PackagesConfig>
+        <FileSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileSemanticVersion>
     </PropertyGroup>
-    <Target Name="_RestorePackages" DependsOnTargets="_DisplayInfo">
-        <NugetRestore NugetPath="$(FileNuGetExe)" PackageFile="$(PackagesConfig)" PackageDirectory="$(DirPackages)" />
-    </Target>
-    
-    <PropertyGroup>
-        <FileGitVersionExe>GitHubFlowVersion.exe</FileGitVersionExe>
-    </PropertyGroup>
-    <Target Name="_GetSemanticVersion" DependsOnTargets="_DisplayInfo;_RestorePackages">
-        <FindToolFromPackages PackagesDir="$(DirPackages)" FileToLocate="$(FileGitVersionExe)">
-            <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
-        </FindToolFromPackages>
-        
-        <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+    <Target Name="_GetSemanticVersion" DependsOnTargets="_DisplayInfo;">
+        <GetSemanticVersion VersionFile="$(FileSemanticVersion)">
             <Output TaskParameter="VersionSemantic" PropertyName="VersionSemantic" />
         </GetSemanticVersion>
     </Target>
@@ -57,7 +42,7 @@
     <PropertyGroup>
         <FileReleaseNotes>$(DirBuildTemp)\releasenotes_short.md</FileReleaseNotes>
     </PropertyGroup>
-    <Target Name="_LoadReleaseNotes" DependsOnTargets="_DisplayInfo;_RestorePackages;_GetSemanticVersion">
+    <Target Name="_LoadReleaseNotes" DependsOnTargets="_DisplayInfo;_GetSemanticVersion">
         <CreateProperty Condition="Exists('$(FileReleaseNotes)')" Value="$([System.IO.File]::ReadAllText('$(FileReleaseNotes)'))">
             <Output TaskParameter="Value" PropertyName="ReleaseNotes" />
         </CreateProperty>
@@ -66,7 +51,7 @@
     <PropertyGroup>
         <ExeGit>$(DirGit)\git.exe</ExeGit>
     </PropertyGroup>
-    <Target Name="_TagRelease" DependsOnTargets="_DisplayInfo;_RestorePackages;_GetSemanticVersion;_LoadReleaseNotes" Condition="Exists('$(DirGit)') AND Exists('$(FileReleaseNotes)')" >
+    <Target Name="_TagRelease" DependsOnTargets="_DisplayInfo;_GetSemanticVersion;_LoadReleaseNotes" Condition="Exists('$(DirGit)') AND Exists('$(FileReleaseNotes)')" >
         <Exec Command="&quot;$(ExeGit)&quot; tag -a -m &quot;$(ReleaseNotes)&quot; &quot;$(VersionSemantic)&quot;"
               WorkingDirectory="$(DirWorkspace)" />
         <Exec Command="&quot;$(ExeGit)&quot; push origin --tags"

--- a/src/solutionlevel/SolutionLevel.csproj
+++ b/src/solutionlevel/SolutionLevel.csproj
@@ -41,6 +41,7 @@
     <FileGeneratedAssemblyVersion>$(DirBuildTemp)\AssemblyInfo.VersionNumber.cs</FileGeneratedAssemblyVersion>
     <FileGeneratedAssemblyBuildInfo>$(DirBuildTemp)\AssemblyInfo.BuildInformation.cs</FileGeneratedAssemblyBuildInfo>
     <FileGeneratedLicenses>$(DirBuildTemp)\licenses.xml</FileGeneratedLicenses>
+    <FileGeneratedSemanticVersion>$(DirBuildTemp)\semantic_version.json</FileGeneratedSemanticVersion>
     <!-- Version number -->
     <VersionMajor>0</VersionMajor>
     <VersionMinor>0</VersionMinor>
@@ -58,6 +59,7 @@
   </PropertyGroup>
   <Import Project="$(MsBuildExtensionsPath)\TemplateFile.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\TemplateFile.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\FindToolFromPackages.msbuild')" />
+  <Import Project="$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\CalculateSemanticVersion.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\GetSemanticVersion.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\GitCommitHash.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\GitCommitHash.msbuild')" />
   <Import Project="$(MsBuildExtensionsPath)\PublicKeySignatureFromAssembly.msbuild" Condition="Exists('$(MsBuildExtensionsPath)\PublicKeySignatureFromAssembly.msbuild')" />
@@ -79,6 +81,7 @@
       <GeneratedFiles Include="$(FileGeneratedAssemblyVersion)" />
       <GeneratedFiles Include="$(FileGeneratedAssemblyBuildInfo)" />
       <GeneratedFiles Include="$(FileGeneratedLicenses)" />
+      <GeneratedFiles Include="$(FileGeneratedSemanticVersion)" />
     </ItemGroup>
     <Delete Files="@(GeneratedFiles)" />
   </Target>
@@ -99,7 +102,9 @@
       <Output TaskParameter="Path" PropertyName="PathGitVersionExe" />
     </FindToolFromPackages>
     
-    <GetSemanticVersion ExePath="$(PathGitVersionExe)" TempDirectory="$(DirBuildTemp)">
+    <CalculateSemanticVersion ExePath="$(PathGitVersionExe)" VersionFile="$(FileGeneratedSemanticVersion)" Condition="!Exists('$(FileGeneratedSemanticVersion)')" />
+    
+    <GetSemanticVersion VersionFile="$(FileGeneratedSemanticVersion)">
         <Output TaskParameter="VersionMajor" PropertyName="VersionMajor" />
         <Output TaskParameter="VersionMinor" PropertyName="VersionMinor" />
         <Output TaskParameter="VersionPatch" PropertyName="VersionPatch" />

--- a/tools/msbuild.extensions/CalculateSemanticVersion.msbuild
+++ b/tools/msbuild.extensions/CalculateSemanticVersion.msbuild
@@ -1,0 +1,70 @@
+<!-- 
+     Copyright 2013 nAnicitus. Licensed under the Apache License, Version 2.0.
+-->
+
+<Project xmlns='http://schemas.microsoft.com/developer/msbuild/2003' 
+         ToolsVersion="4.0">
+    <UsingTask TaskName="CalculateSemanticVersion" 
+               TaskFactory="CodeTaskFactory" 
+               AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+        <ParameterGroup>
+            <ExePath ParameterType="System.String" Required="true" />
+            <VersionFile ParameterType="System.String" Required="true" />
+        </ParameterGroup>
+        <Task>
+            <Code Type="Method" Language="cs">
+                <![CDATA[
+                    public override bool Execute()
+                    {
+                        var info = new System.Diagnostics.ProcessStartInfo
+                        {
+                            FileName = ExePath,
+                            Arguments = string.Format("/ToFile \"{0}\"", VersionFile),
+                            UseShellExecute = false,
+                            RedirectStandardOutput = true,
+                            RedirectStandardError = true,
+                        };
+                        
+                        Log.LogMessage(MessageImportance.Normal, ExePath);
+                        Log.LogMessage(MessageImportance.Normal, info.Arguments);
+                        
+                        var process = new System.Diagnostics.Process();
+                        process.StartInfo = info;
+                        process.OutputDataReceived +=
+                            (s, e) =>
+                            {
+                                if (!string.IsNullOrWhiteSpace(e.Data))
+                                {
+                                    Log.LogMessage(MessageImportance.Normal, e.Data);
+                                }
+                            };
+                        process.ErrorDataReceived +=
+                            (s, e) =>
+                            {
+                                if (!string.IsNullOrWhiteSpace(e.Data))
+                                {
+                                    Log.LogError(e.Data);
+                                }
+                            };
+                        process.Start();
+
+                        process.BeginOutputReadLine();
+                        process.BeginErrorReadLine();
+                        process.WaitForExit();
+                        
+                        if (process.ExitCode != 0)
+                        {
+                            Log.LogError("Failed to get semantic version information");
+                            return false;
+                        }
+                        
+                        // Log.HasLoggedErrors is true if the task logged any errors -- even if they were logged 
+                        // from a task's constructor or property setter. As long as this task is written to always log an error
+                        // when it fails, we can reliably return HasLoggedErrors.
+                        return !Log.HasLoggedErrors;
+                    }
+                ]]>  
+            </Code>
+        </Task>
+    </UsingTask>
+</Project>

--- a/tools/msbuild.extensions/GetSemanticVersion.msbuild
+++ b/tools/msbuild.extensions/GetSemanticVersion.msbuild
@@ -8,8 +8,7 @@
                TaskFactory="CodeTaskFactory" 
                AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
         <ParameterGroup>
-            <ExePath ParameterType="System.String" Required="true" />
-            <TempDirectory ParameterType="System.String" Required="true" />
+            <VersionFile ParameterType="System.String" Required="true" />
             <VersionMajor ParameterType="System.String" Output="true" />
             <VersionMinor ParameterType="System.String" Output="true" />
             <VersionPatch ParameterType="System.String" Output="true" />
@@ -22,53 +21,10 @@
                 <![CDATA[
                     public override bool Execute()
                     {
-                        var outputPath = System.IO.Path.Combine(TempDirectory, "semantic_version.json");
-                        var info = new System.Diagnostics.ProcessStartInfo
-                        {
-                            FileName = ExePath,
-                            Arguments = string.Format("/ToFile \"{0}\"", outputPath),
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true,
-                            RedirectStandardError = true,
-                        };
-                        
-                        Log.LogMessage(MessageImportance.Normal, ExePath);
-                        Log.LogMessage(MessageImportance.Normal, info.Arguments);
-                        
-                        var process = new System.Diagnostics.Process();
-                        process.StartInfo = info;
-                        process.OutputDataReceived +=
-                            (s, e) =>
-                            {
-                                if (!string.IsNullOrWhiteSpace(e.Data))
-                                {
-                                    Log.LogMessage(MessageImportance.Normal, e.Data);
-                                }
-                            };
-                        process.ErrorDataReceived +=
-                            (s, e) =>
-                            {
-                                if (!string.IsNullOrWhiteSpace(e.Data))
-                                {
-                                    Log.LogError(e.Data);
-                                }
-                            };
-                        process.Start();
-
-                        process.BeginOutputReadLine();
-                        process.BeginErrorReadLine();
-                        process.WaitForExit();
-                        
-                        if (process.ExitCode != 0)
-                        {
-                            Log.LogError("Failed to get semantic version information");
-                            return false;
-                        }
-                        
                         try
                         {
                             string text;
-                            using (var reader = new System.IO.StreamReader(outputPath))
+                            using (var reader = new System.IO.StreamReader(VersionFile))
                             {
                                 text = reader.ReadToEnd();
                             }


### PR DESCRIPTION
The Deploy.GitTag.msbuild script should use the same version file as the build process did.
